### PR TITLE
Feature/#59 OPTIONS 요청에선 토큰 검증 패스하도록 수정 

### DIFF
--- a/crossover-server-2/src/main/java/org/example/crossoverserver2/planeletter/authentication/AuthenticationInterceptor.java
+++ b/crossover-server-2/src/main/java/org/example/crossoverserver2/planeletter/authentication/AuthenticationInterceptor.java
@@ -23,6 +23,9 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     public boolean preHandle(final HttpServletRequest request,
                              final HttpServletResponse response,
                              final Object handler) throws Exception {
+        if(request.getMethod().equals("OPTIONS")){
+            return true;
+        }
         String accessToken = AuthenticationExtractor.extract(request);
         UUID id = UUID.fromString(jwtTokenProvider.getPayload(accessToken)); // accessToken에서 payload추출
         User user = findUserByUserId(id);


### PR DESCRIPTION
## Description
OPTIONS 요청에선 토큰 검증 패스하도록 수정

## Changes
- [x] AuthenticationInterceptor


## Additional context
OPTIONS 요청에선 토큰 검증 패스하도록 수정.Preflight Request를 보낼 때 OPTIONS 요청의 헤더에 토큰이 보내지지 않았기 때문에 이때는 유저 검증을 하지 않도록 인터셉터를 리팩토링

Closes #59
